### PR TITLE
홈친구수정

### DIFF
--- a/components/NotificationPanel.tsx
+++ b/components/NotificationPanel.tsx
@@ -62,6 +62,15 @@ interface Notification {
     message: string;
     created_at: string;
     read: boolean;
+    metadata?: {
+        session_ids?: string[];
+        thread_id?: string;
+        from_user_id?: string;
+        schedule_date?: string;
+        schedule_time?: string;
+        schedule_activity?: string;
+        [key: string]: any;
+    };
 }
 
 interface NotificationPanelProps {
@@ -172,7 +181,10 @@ export default function NotificationPanel({
                     onNavigateToFriends?.('friends');
                     break;
                 case 'schedule_rejected':
-                    // Could navigate to A2A or stay
+                    // 관련 A2A 세션으로 이동
+                    if (item.metadata?.session_ids?.[0]) {
+                        onNavigateToA2A(item.metadata.session_ids[0]);
+                    }
                     break;
                 default:
                     break;

--- a/screens/A2AScreen.tsx
+++ b/screens/A2AScreen.tsx
@@ -53,9 +53,9 @@ const COLORS = {
     neutral200: '#E5E7EB',
     neutral300: '#D1D5DB',
     neutral400: '#9CA3AF',
-    neutral400: '#9CA3AF',
     neutral500: '#6B7280',
     neutral600: '#4B5563',
+    neutral700: '#374151',
     neutral900: '#111827', // Added for calendar title
     white: '#FFFFFF',
     green600: '#16A34A',
@@ -917,38 +917,48 @@ const A2AScreen = () => {
 
     const handleRejectClick = async () => {
         if (!selectedLog) return;
-        // currently reuse reschedule logic or simple alert
-        // User asked for "Reject" button specifically. 
-        // For now, let's treat it as a hard reject (maybe same as reschedule or just alert).
-        // If we want a distinct reject API call, we need one. 
-        // For now, let's just log it and maybe call reschedule api with a "reject" reason or similar if needed.
-        // Or simply alert "거절하시겠습니까?" and then maybe just close or call an API.
 
-        // Let's implement a basic alert for now as safety
-        // In a real flow, this might call a "reject" endpoint.
         try {
             const token = await AsyncStorage.getItem('accessToken');
-            const res = await fetch(`${API_BASE}/a2a/session/${selectedLog.id}/reject`, { // Assuming an endpoint might exist or we use reschedule
+
+            // 세션 상세 정보에서 proposal 구성
+            const proposal = {
+                date: selectedLog.details?.proposedDate || '',
+                time: selectedLog.details?.proposedTime || '',
+                location: selectedLog.details?.location || '',
+                activity: selectedLog.details?.purpose || selectedLog.title || '',
+                participants: selectedLog.details?.participants || []
+            };
+
+            // /chat/approve-schedule API를 approved: false로 호출
+            const res = await fetch(`${API_BASE}/chat/approve-schedule`, {
                 method: 'POST',
                 headers: {
                     'Authorization': `Bearer ${token}`,
-                }
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    thread_id: selectedLog.details?.thread_id || null,
+                    session_ids: [selectedLog.id],
+                    approved: false,
+                    proposal: proposal
+                })
             });
+
+            const data = await res.json();
+            console.log('🔴 거절 API 응답:', data);
+
             if (res.ok) {
-                alert("일정이 거절되었습니다.");
+                alert("일정이 거절되었습니다. 재조율을 위해 채팅에서 새로운 시간을 입력해주세요.");
                 handleClose();
                 fetchA2ALogs();
             } else {
-                // if 404/405, maybe fallback to reschedule logic or manually set status?
-                // For this demo, let's just alert.
-                console.log("Reject endpoint might not exist, but UI updated.");
-                alert("일정을 거절했습니다.");
-                handleClose();
+                console.error("Reject failed:", data);
+                alert(data.detail || data.error || "거절 처리에 실패했습니다.");
             }
         } catch (e) {
-            console.log(e);
-            alert("일정을 거절했습니다."); // Optimistic UI
-            handleClose();
+            console.error("Reject error:", e);
+            alert("거절 처리 중 오류가 발생했습니다.");
         }
     };
 

--- a/screens/FriendsScreen.tsx
+++ b/screens/FriendsScreen.tsx
@@ -843,12 +843,12 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   tab: {
-    flex: 1,
     paddingVertical: 10,
     paddingHorizontal: 16,
     borderRadius: 12,
     alignItems: 'center',
     backgroundColor: COLORS.neutralLight,
+    flexShrink: 0,
   },
   activeTab: {
     backgroundColor: COLORS.primaryMain,

--- a/types.ts
+++ b/types.ts
@@ -37,6 +37,9 @@ export interface A2ALog {
     proposedTime: string;
     location: string;
     process: { step: string; description: string }[];
+    participants?: string[];
+    thread_id?: string;
+    rescheduleRequestedBy?: string;
   };
   initiator_user_id?: string;
 }

--- a/types/calendar.ts
+++ b/types/calendar.ts
@@ -26,6 +26,7 @@ export interface CreateEventRequest {
   end_time: string;
   attendees?: string[];
   location?: string;
+  is_all_day?: boolean;
 }
 
 export interface CalendarDay {


### PR DESCRIPTION
1. 홈 화면 일정요청카드 x 누르면 다른페이지 갔다와도 안뜨게
2. 일정 거절 누르게 되면 일정 요청카드로 누가누가 어떤 일정을 거절했는지 확인, chat에도 오게하기 (이건 이미 되어 있다함)
3. 홈 화면에서 종 모양 만들고 그 안에 요청카드 뜨게
    오른쪽에서 화면에 스르륵 들어옴 , 뒤로가기 버튼으로(왼쪽 위에)
     친구 탭처럼 안에 메뉴가 두개가 있음
        3.1. 일정 요청 : 이때 두 요청은 탭 색깔로 구분
            1. 새로운 요청 (파란색)
            2. 재조율 요청 (주황색)
        3.2. 기타 알림들 - 일정 거절, 친구 추가 요청
4. 일정요청카드 db 필요없는지 확인 (지금 당장 필요없대)
5. 일정 추가할때 종일 옵션도 추가 (이거 시간 이상했었는데 고침요)
6. 친구탭 내정보 부분 아이디, 이메일 둘다 넣기, 큐알코드 지우기 (아이디 복사는 아이디로 되게 함)
7. 친구 목록에서 이름만 보이게 해놓기
8. 탭 이름 <친구> 없애고 친구목록, 받은요청 버튼 위로
9. 전체 00명 친구 검색 밑에 넣기