### PR TITLE
12/15 수정

### DIFF
--- a/screens/A2AScreen.tsx
+++ b/screens/A2AScreen.tsx
@@ -782,7 +782,7 @@ const A2AScreen = () => {
                 const data = await response.json();
                 const mappedLogs: A2ALog[] = data.sessions.map((session: any) => ({
                     id: session.id,
-                    title: session.title || "일정 조율",
+                    title: session.details?.purpose || session.title || "일정 조율",
                     status: session.status === 'completed' ? 'COMPLETED' : 'IN_PROGRESS',
                     // [✅ 수정] 요약에는 참여자 이름만 표시 (이모지 옆 텍스트)
                     summary: session.participant_names?.join(', ') || "참여자 없음",
@@ -1408,7 +1408,8 @@ const A2AScreen = () => {
                                             <Text style={styles.ticketLabel}>참여자</Text>
                                             <View style={[styles.attendeeStack, { marginTop: 4 }]}>
                                                 {/* 참여자 프로필 이미지 (최대 3개) */}
-                                                {(selectedLog?.details?.participantImages || ['https://picsum.photos/150']).slice(0, 3).map((uri: string, idx: number) => (
+                                                {/* 참여자 프로필 이미지 (최대 3개) */}
+                                                {((selectedLog?.details as any)?.attendees?.map((a: any) => a.avatar) || (selectedLog?.details as any)?.participantImages || ['https://picsum.photos/150']).slice(0, 3).map((uri: string, idx: number) => (
                                                     <Image
                                                         key={idx}
                                                         source={{ uri: uri || 'https://picsum.photos/150' }}


### PR DESCRIPTION
### 메인 화면
1. 제목 형식: 참여자랑 시간 없애고, 핵심 내용만(회의, 미팅, 약속, 장소)

### 개별 탭
1. 새로운 일정 요청이랑 재조율 일정 요청 구분
2. 새로운 일정 요청 밑에 요청온 시간으로 뜨게
3. 참여자 목록에서 프로필 클릭하면 해당 프로필 사람 이름 뜨게
    1. 프로필 이미지 크롬에서는 떴다 안떴다 하고 사파리에서는 잘뜸,..뭐지

### 재조율
1. 재조율 요청 보낸거 화면 한국어로
2. 재조율 보낸거 여러명일때 몇명 안가는 이슈 있음
3. 재조율 시간 날짜 클릭> 오전/오후 클릭> 시간 전체 활성화 시킴
4. 재조율 누르면 뜨는 화면 상단에 선택된 재조율 시간 부분에 ‘기존 시간→변경요청시간’

### 승인
1. 승인 누르면 뜨는 카드 한국어로
2. 장소랑 참여자 한국어로 표시

### 거절
1. 거절 누르면 홈화면 알림에 거절했다고 오게 하고, 이벤트 탭에는 거절과 동시에 아예 삭제.
2. 거절 누르면 거절되엇습니다. 일정이 삭제됩니다. → 이것도 팝업 디자인으로 뜨게. 자체 크롬팝업 말고
3. 거절 누르면 chat에 안뜸