### PR TITLE
1/5일 회의 전 수정사항

### DIFF
--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -489,8 +489,17 @@ export default function HomeScreen() {
           const start = new Date(event.start.dateTime || event.start.date || '');
           const end = new Date(event.end.dateTime || event.end.date || '');
 
-          date = start.toISOString().split('T')[0];
-          endDateStr = end.toISOString().split('T')[0];
+          // [FIX] toISOString() 대신 로컬 시간대 기반 날짜 추출
+          // toISOString()은 UTC로 변환하여 KST 오전 시간이 전날로 표시되는 문제 발생
+          const formatLocalDate = (d: Date) => {
+            const year = d.getFullYear();
+            const month = String(d.getMonth() + 1).padStart(2, '0');
+            const day = String(d.getDate()).padStart(2, '0');
+            return `${year}-${month}-${day}`;
+          };
+
+          date = formatLocalDate(start);
+          endDateStr = formatLocalDate(end);
 
           startTime = start.toTimeString().slice(0, 5);
           endTime = end.toTimeString().slice(0, 5);


### PR DESCRIPTION
- 이벤트 페이지 들어갈때 로딩시간이 너무 길어짐
- chat에서 분단위 캘린더 저장 안됨(개인일정) → a2a쪽도 확인해서 고침
- 채팅 기억을 너무 오래 가지고 있음. → 1시간 지나면 새로운 메세지를 입력해달라고 요청